### PR TITLE
Fix parallel data providers

### DIFF
--- a/src/test/java/org/junit/support/testng/engine/DataProviderIntegrationTests.java
+++ b/src/test/java/org/junit/support/testng/engine/DataProviderIntegrationTests.java
@@ -36,6 +36,7 @@ import example.dataproviders.DataProviderMethodEmptyListTestCase;
 import example.dataproviders.DataProviderMethodErrorHandlingTestCase;
 import example.dataproviders.DataProviderMethodTestCase;
 import example.dataproviders.FactoryWithDataProviderTestCase;
+import example.dataproviders.ParallelDataProviderTestCase;
 
 import org.junit.jupiter.api.Test;
 import org.junit.platform.engine.TestDescriptor;
@@ -190,5 +191,20 @@ class DataProviderIntegrationTests extends AbstractIntegrationTests {
 		results.allEvents().assertEventsMatchExactly( //
 			event(engine(), started()), //
 			event(engine(), finishedSuccessfully()));
+	}
+
+	@Test
+	void reportsParallelDataProviderCorrectly() {
+		var testClass = ParallelDataProviderTestCase.class;
+
+		var results = testNGEngine().selectors(selectClass(testClass)).execute();
+
+		results.containerEvents().debug().assertEventsMatchLooselyInOrder( //
+			event(testClass(testClass), started()), //
+			event(container("method:test(java.lang.Integer)"), started()), //
+			event(container("method:test(java.lang.Integer)"), finishedSuccessfully()), //
+			event(testClass(testClass), finishedSuccessfully()));
+		results.testEvents().assertStatistics(
+			stats -> stats.dynamicallyRegistered(11).started(11).succeeded(11).finished(11));
 	}
 }

--- a/src/testFixtures/java/example/dataproviders/ParallelDataProviderTestCase.java
+++ b/src/testFixtures/java/example/dataproviders/ParallelDataProviderTestCase.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.dataproviders;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.stream.IntStream;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class ParallelDataProviderTestCase {
+
+	@DataProvider(name = "numbers", parallel = true)
+	public static Iterator<Object[]> numbers() {
+		return IntStream.of(1, 3, 5, 7, 9, 11, 13, -5, -3, 15, Integer.MAX_VALUE) //
+				.mapToObj(Arrays::asList) //
+				.map(Collection::toArray) //
+				.iterator();
+	}
+
+	@Test(dataProvider = "numbers")
+	public void test(Integer number) {
+	}
+
+}


### PR DESCRIPTION
Since `org.testng.ITestNGMethod#getId` is not reliable, the execution
listener now uses the ITestResult as a key to find the correct
invocation and does not eagerly report the method container as finished
but relies on onAfterClass to do so. This approach is also used by
Gradle's listener implementation so it should be robust.

Fixes #4.