### PR TITLE
Using TCK Tested JDK builds of OpenJDK

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: zulu
           java-version: ${{ matrix.jdk }}
       - run: ./gradlew build --scan -Dscan.tag.JDK_${{ matrix.jdk }}
         env:
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: zulu
           java-version: 11
       - run: ./gradlew publish -x check --scan -Dscan.tag.publish
         env:


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued since July 2021. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK.