### PR TITLE
Add support for nested test classes

### DIFF
--- a/src/main/java/org/junit/support/testng/engine/ExecutionListener.java
+++ b/src/main/java/org/junit/support/testng/engine/ExecutionListener.java
@@ -55,7 +55,7 @@ class ExecutionListener extends DefaultListener {
 	public void onBeforeClass(ITestClass testClass) {
 		ClassDescriptor classDescriptor = requireNonNull(engineDescriptor.findClassDescriptor(testClass.getRealClass()),
 			"Missing class descriptor");
-		testClassRegistry.start(testClass.getRealClass(), () -> {
+		testClassRegistry.start(testClass.getRealClass(), __ -> {
 			delegate.executionStarted(classDescriptor);
 			return classDescriptor;
 		});

--- a/src/main/java/org/junit/support/testng/engine/TestNGTestEngine.java
+++ b/src/main/java/org/junit/support/testng/engine/TestNGTestEngine.java
@@ -84,7 +84,7 @@ public class TestNGTestEngine implements TestEngine {
 		List<String> methodNames = engineDescriptor.getQualifiedMethodNames();
 
 		ConfigurationParameters configurationParameters = request.getConfigurationParameters();
-		DiscoveryListener listener = new DiscoveryListener(engineDescriptor);
+		DiscoveryListener listener = new DiscoveryListener(request, engineDescriptor);
 
 		if (testClasses.length > 0) {
 			withTemporarySystemProperty(TESTNG_MODE_DRYRUN, "true",

--- a/src/test/java/org/junit/support/testng/engine/DiscoveryIntegrationTests.java
+++ b/src/test/java/org/junit/support/testng/engine/DiscoveryIntegrationTests.java
@@ -32,6 +32,7 @@ import example.basics.IgnoredTestCase;
 import example.basics.InheritedClassLevelOnlyAnnotationTestCase;
 import example.basics.InheritingSubClassTestCase;
 import example.basics.JUnitTestCase;
+import example.basics.NestedTestClass;
 import example.basics.SimpleTestCase;
 import example.basics.SuccessPercentageTestCase;
 import example.basics.TwoMethodsTestCase;
@@ -285,6 +286,32 @@ class DiscoveryIntegrationTests extends AbstractIntegrationTests {
 		var rootDescriptor = testEngine.discover(request, engineId);
 
 		assertThat(rootDescriptor.getChildren()).isEmpty();
+	}
+
+	@Test
+	void discoversNestedTestClasses() {
+		var selectedTestClass = NestedTestClass.class;
+		var request = request().selectors(selectClass(selectedTestClass)).build();
+
+		var rootDescriptor = testEngine.discover(request, engineId);
+
+		assertThat(rootDescriptor.getUniqueId()).isEqualTo(engineId);
+		assertThat(rootDescriptor.getChildren()).hasSize(2);
+
+		Map<String, TestDescriptor> classDescriptors = rootDescriptor.getChildren().stream() //
+				.collect(toMap(TestDescriptor::getDisplayName, identity()));
+
+		TestDescriptor classDescriptor = classDescriptors.get("A");
+		assertThat(classDescriptor.getLegacyReportingName()).isEqualTo(NestedTestClass.A.class.getName());
+		assertThat(classDescriptor.getType()).isEqualTo(CONTAINER);
+		assertThat(classDescriptor.getSource()).contains(ClassSource.from(NestedTestClass.A.class));
+		assertThat(classDescriptor.getChildren()).hasSize(1);
+
+		classDescriptor = classDescriptors.get("B");
+		assertThat(classDescriptor.getLegacyReportingName()).isEqualTo(NestedTestClass.B.class.getName());
+		assertThat(classDescriptor.getType()).isEqualTo(CONTAINER);
+		assertThat(classDescriptor.getSource()).contains(ClassSource.from(NestedTestClass.B.class));
+		assertThat(classDescriptor.getChildren()).hasSize(1);
 	}
 
 	interface InterfaceTestCase {

--- a/src/test/java/org/junit/support/testng/engine/ReportingIntegrationTests.java
+++ b/src/test/java/org/junit/support/testng/engine/ReportingIntegrationTests.java
@@ -13,6 +13,7 @@ package org.junit.support.testng.engine;
 import static org.junit.platform.commons.util.StringUtils.isBlank;
 import static org.junit.platform.engine.FilterResult.excluded;
 import static org.junit.platform.engine.FilterResult.includedIf;
+import static org.junit.platform.engine.discovery.ClassNameFilter.excludeClassNamePatterns;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUniqueId;
@@ -35,6 +36,7 @@ import java.util.Map;
 import example.basics.CustomAttributeTestCase;
 import example.basics.ExpectedExceptionsTestCase;
 import example.basics.InheritingSubClassTestCase;
+import example.basics.NestedTestClass;
 import example.basics.ParallelExecutionTestCase;
 import example.basics.RetriedTestCase;
 import example.basics.SimpleTestCase;
@@ -46,6 +48,7 @@ import example.dataproviders.DataProviderMethodTestCase;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.platform.engine.Filter;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.MethodSource;
 import org.junit.platform.launcher.PostDiscoveryFilter;
@@ -300,6 +303,19 @@ class ReportingIntegrationTests extends AbstractIntegrationTests {
 			event(test("method:test()"), dynamicTestRegistered("invoc")), //
 			event(container("method:test()"), finishedSuccessfully()), //
 			event(testClass(testClass), finishedSuccessfully()));
+	}
+
+	@Test
+	void onlyExecutesNestedTestClassesThatMatchClassNameFilter() {
+		var selectedTestClass = NestedTestClass.class;
+
+		var results = testNGEngine() //
+				.selectors(selectClass(selectedTestClass)) //
+				.filters((Filter<?>) excludeClassNamePatterns(".*A$")) //
+				.execute();
+
+		results.containerEvents().assertStatistics(stats -> stats.started(2).finished(2));
+		results.testEvents().assertStatistics(stats -> stats.started(1).finished(1));
 	}
 
 }

--- a/src/testFixtures/java/example/basics/NestedTestClass.java
+++ b/src/testFixtures/java/example/basics/NestedTestClass.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.basics;
+
+import org.testng.annotations.Test;
+
+public class NestedTestClass {
+
+	public static class A {
+		@Test
+		public void test() {
+		}
+	}
+
+	public static class B {
+		@Test
+		public void test() {
+		}
+	}
+}


### PR DESCRIPTION
When asked to run a top-level test class, TestNG also runs any static
nested test classes. Prior to this commit such scenarios resulted in
NPEs being thrown during discovery.

Fixes #13.