### PR TITLE
Fix reporting of tests using `Factory` methods

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        jdk: ['17']
+        jdk: ['17', '18']
     runs-on: ubuntu-latest
     name: "Build (JDK ${{ matrix.jdk }})"
     steps:
@@ -36,21 +36,17 @@ jobs:
   ea-build:
     strategy:
       matrix:
-        jdk: ['18']
+        jdk: ['19']
     runs-on: ubuntu-latest
     name: "Early Access Build (JDK ${{ matrix.jdk }})"
     steps:
       - uses: actions/checkout@v2
-      - name: 'Download JDK ${{ matrix.jdk }}'
-        id: download-jdk
-        uses: sormuras/download-jdk@v1
+      - name: 'Set up JDK ${{ matrix.jdk }}'
+        uses: oracle-actions/setup-java@v1
         with:
-          feature: '${{ matrix.jdk }}'
-      - uses: actions/setup-java@v2
-        with:
-          distribution: 'jdkfile'
-          java-version: '${{ steps.download-jdk.outputs.version }}'
-          jdkFile: '${{ steps.download-jdk.outputs.file }}'
+          website: jdk.java.net
+          release: ${{ matrix.jdk }}
+          version: latest
       - uses: gradle/gradle-build-action@v2
         env:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,6 @@ plugins {
 
 java {
     toolchain.languageVersion.set(providers.gradleProperty("javaToolchainVersion")
-        .forUseAtConfigurationTime()
         .map { JavaLanguageVersion.of(it) }
         .orElse(JavaLanguageVersion.of(17)))
     withJavadocJar()

--- a/src/main/java/org/junit/support/testng/engine/ClassDescriptor.java
+++ b/src/main/java/org/junit/support/testng/engine/ClassDescriptor.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
 import org.junit.platform.engine.TestDescriptor;
@@ -35,6 +36,7 @@ class ClassDescriptor extends AbstractTestDescriptor {
 	private final ConcurrentMap<String, MethodDescriptor> methodsById = new ConcurrentHashMap<>();
 	private final Class<?> testClass;
 	private final Set<TestTag> tags;
+	final AtomicInteger remainingFinishes = new AtomicInteger();
 	ExecutionStrategy executionStrategy = new IncludeMethodsExecutionStrategy();
 
 	ClassDescriptor(UniqueId uniqueId, Class<?> testClass, Set<TestTag> tags) {

--- a/src/main/java/org/junit/support/testng/engine/ClassDescriptor.java
+++ b/src/main/java/org/junit/support/testng/engine/ClassDescriptor.java
@@ -36,7 +36,7 @@ class ClassDescriptor extends AbstractTestDescriptor {
 	private final ConcurrentMap<String, MethodDescriptor> methodsById = new ConcurrentHashMap<>();
 	private final Class<?> testClass;
 	private final Set<TestTag> tags;
-	final AtomicInteger remainingFinishes = new AtomicInteger();
+	final AtomicInteger remainingIterations = new AtomicInteger();
 	ExecutionStrategy executionStrategy = new IncludeMethodsExecutionStrategy();
 
 	ClassDescriptor(UniqueId uniqueId, Class<?> testClass, Set<TestTag> tags) {

--- a/src/main/java/org/junit/support/testng/engine/DiscoveryListener.java
+++ b/src/main/java/org/junit/support/testng/engine/DiscoveryListener.java
@@ -11,6 +11,7 @@
 package org.junit.support.testng.engine;
 
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -67,9 +68,22 @@ class DiscoveryListener extends DefaultListener {
 		addMethodDescriptor(result);
 	}
 
+	@Override
+	public void onTestFailure(ITestResult result) {
+		getClassDescriptor(result).ifPresent(classDescriptor -> addMethodDescriptor(result, classDescriptor));
+	}
+
 	private void addMethodDescriptor(ITestResult result) {
-		ClassDescriptor classDescriptor = testClassRegistry.get(result.getTestClass().getRealClass()) //
+		ClassDescriptor classDescriptor = getClassDescriptor(result) //
 				.orElseThrow(() -> new IllegalStateException("Missing class descriptor for " + result.getTestClass()));
+		addMethodDescriptor(result, classDescriptor);
+	}
+
+	private Optional<ClassDescriptor> getClassDescriptor(ITestResult result) {
+		return testClassRegistry.get(result.getTestClass().getRealClass());
+	}
+
+	private void addMethodDescriptor(ITestResult result, ClassDescriptor classDescriptor) {
 		if (!classDescriptor.findMethodDescriptor(result).isPresent()) {
 			classDescriptor.addChild(
 				engineDescriptor.getTestDescriptorFactory().createMethodDescriptor(classDescriptor, result));

--- a/src/main/java/org/junit/support/testng/engine/DiscoveryListener.java
+++ b/src/main/java/org/junit/support/testng/engine/DiscoveryListener.java
@@ -55,7 +55,7 @@ class DiscoveryListener extends DefaultListener {
 	@Override
 	public void onAfterClass(ITestClass testClass) {
 		testClassRegistry.finish(testClass.getRealClass(), __ -> true,
-			classDescriptor -> classDescriptor.remainingFinishes.incrementAndGet());
+			classDescriptor -> classDescriptor.remainingIterations.incrementAndGet());
 	}
 
 	@Override

--- a/src/main/java/org/junit/support/testng/engine/DiscoveryListener.java
+++ b/src/main/java/org/junit/support/testng/engine/DiscoveryListener.java
@@ -53,9 +53,8 @@ class DiscoveryListener extends DefaultListener {
 
 	@Override
 	public void onAfterClass(ITestClass testClass) {
-		testClassRegistry.finish(testClass.getRealClass(), __ -> {
-			// do nothing
-		});
+		testClassRegistry.finish(testClass.getRealClass(), __ -> true,
+			classDescriptor -> classDescriptor.remainingFinishes.incrementAndGet());
 	}
 
 	@Override

--- a/src/main/java/org/junit/support/testng/engine/ExecutionListener.java
+++ b/src/main/java/org/junit/support/testng/engine/ExecutionListener.java
@@ -75,11 +75,12 @@ class ExecutionListener extends DefaultListener {
 
 	@Override
 	public void onAfterClass(ITestClass testClass) {
-		testClassRegistry.finish(testClass.getRealClass(), classDescriptor -> {
-			finishMethodsNotYetReportedAsFinished(testClass);
-			Set<Throwable> failures = classFailures.remove(classDescriptor);
-			delegate.executionFinished(classDescriptor, toTestExecutionResult(failures));
-		});
+		testClassRegistry.finish(testClass.getRealClass(),
+			classDescriptor -> classDescriptor.remainingFinishes.decrementAndGet() == 0, classDescriptor -> {
+				finishMethodsNotYetReportedAsFinished(testClass);
+				Set<Throwable> failures = classFailures.remove(classDescriptor);
+				delegate.executionFinished(classDescriptor, toTestExecutionResult(failures));
+			});
 	}
 
 	@Override

--- a/src/main/java/org/junit/support/testng/engine/ExecutionListener.java
+++ b/src/main/java/org/junit/support/testng/engine/ExecutionListener.java
@@ -76,7 +76,7 @@ class ExecutionListener extends DefaultListener {
 	@Override
 	public void onAfterClass(ITestClass testClass) {
 		testClassRegistry.finish(testClass.getRealClass(),
-			classDescriptor -> classDescriptor.remainingFinishes.decrementAndGet() == 0, classDescriptor -> {
+			classDescriptor -> classDescriptor.remainingIterations.decrementAndGet() == 0, classDescriptor -> {
 				finishMethodsNotYetReportedAsFinished(testClass);
 				Set<Throwable> failures = classFailures.remove(classDescriptor);
 				delegate.executionFinished(classDescriptor, toTestExecutionResult(failures));

--- a/src/main/java/org/junit/support/testng/engine/ExecutionListener.java
+++ b/src/main/java/org/junit/support/testng/engine/ExecutionListener.java
@@ -123,6 +123,9 @@ class ExecutionListener extends DefaultListener {
 
 	@Override
 	public void onTestFailure(ITestResult result) {
+		if (!inProgressTestMethods.containsKey(result.getMethod())) {
+			reportStarted(result, startMethodProgress(result));
+		}
 		reportFinished(result, failed(result.getThrowable()));
 	}
 

--- a/src/main/java/org/junit/support/testng/engine/LoggingListener.java
+++ b/src/main/java/org/junit/support/testng/engine/LoggingListener.java
@@ -11,6 +11,7 @@
 package org.junit.support.testng.engine;
 
 import java.util.List;
+import java.util.function.Supplier;
 import java.util.logging.Logger;
 
 import org.testng.ITestClass;
@@ -29,96 +30,100 @@ class LoggingListener extends DefaultListener {
 
 	@Override
 	public void alter(List<XmlSuite> suites) {
-		LOGGER.fine(() -> "alter: " + suites);
+		log(() -> "alter: " + suites);
 	}
 
 	@Override
 	public void onBeforeClass(ITestClass testClass) {
-		LOGGER.fine(() -> "onBeforeClass: " + testClass);
+		log(() -> "onBeforeClass: " + testClass);
 	}
 
 	@Override
 	public void onAfterClass(ITestClass testClass) {
-		LOGGER.fine(() -> "onAfterClass: " + testClass);
+		log(() -> "onAfterClass: " + testClass);
 	}
 
 	@Override
 	public void onTestStart(ITestResult result) {
-		LOGGER.fine(() -> "onTestStart: " + result);
+		log(() -> "onTestStart: " + result);
 	}
 
 	@Override
 	public void onTestSuccess(ITestResult result) {
-		LOGGER.fine(() -> "onTestSuccess: " + result);
+		log(() -> "onTestSuccess: " + result);
 	}
 
 	@Override
 	public void onTestFailure(ITestResult result) {
-		LOGGER.fine(() -> "onTestFailure: " + result);
+		log(() -> "onTestFailure: " + result);
 	}
 
 	@Override
 	public void onTestSkipped(ITestResult result) {
-		LOGGER.fine(() -> "onTestSkipped: " + result);
+		log(() -> "onTestSkipped: " + result);
 	}
 
 	@Override
 	public void onTestFailedButWithinSuccessPercentage(ITestResult result) {
-		LOGGER.fine(() -> "onTestFailedButWithinSuccessPercentage: " + result);
+		log(() -> "onTestFailedButWithinSuccessPercentage: " + result);
 	}
 
 	@Override
 	public void onTestFailedWithTimeout(ITestResult result) {
-		LOGGER.fine(() -> "onTestFailedWithTimeout: " + result);
+		log(() -> "onTestFailedWithTimeout: " + result);
 	}
 
 	@Override
 	public void onStart(ITestContext context) {
-		LOGGER.fine(() -> "onStart: " + context);
+		log(() -> "onStart: " + context);
 	}
 
 	@Override
 	public void onFinish(ITestContext context) {
-		LOGGER.fine(() -> "onFinish: " + context);
+		log(() -> "onFinish: " + context);
 	}
 
 	@Override
 	public void onConfigurationSuccess(ITestResult tr) {
-		LOGGER.fine(() -> "onConfigurationSuccess: " + tr);
+		log(() -> "onConfigurationSuccess: " + tr);
 	}
 
 	@Override
 	public void onConfigurationSuccess(ITestResult tr, ITestNGMethod tm) {
-		LOGGER.fine(() -> "onConfigurationSuccess: " + tr + ", " + tm);
+		log(() -> "onConfigurationSuccess: " + tr + ", " + tm);
 	}
 
 	@Override
 	public void onConfigurationFailure(ITestResult tr) {
-		LOGGER.fine(() -> "onConfigurationFailure: " + tr);
+		log(() -> "onConfigurationFailure: " + tr);
 	}
 
 	@Override
 	public void onConfigurationFailure(ITestResult tr, ITestNGMethod tm) {
-		LOGGER.fine(() -> "onConfigurationFailure: " + tr + ", " + tm);
+		log(() -> "onConfigurationFailure: " + tr + ", " + tm);
 	}
 
 	@Override
 	public void onConfigurationSkip(ITestResult tr) {
-		LOGGER.fine(() -> "onConfigurationSkip: " + tr);
+		log(() -> "onConfigurationSkip: " + tr);
 	}
 
 	@Override
 	public void onConfigurationSkip(ITestResult tr, ITestNGMethod tm) {
-		LOGGER.fine(() -> "onConfigurationSkip: " + tr + ", " + tm);
+		log(() -> "onConfigurationSkip: " + tr + ", " + tm);
 	}
 
 	@Override
 	public void beforeConfiguration(ITestResult tr) {
-		LOGGER.fine(() -> "beforeConfiguration: " + tr);
+		log(() -> "beforeConfiguration: " + tr);
 	}
 
 	@Override
 	public void beforeConfiguration(ITestResult tr, ITestNGMethod tm) {
-		LOGGER.fine(() -> "beforeConfiguration: " + tr + ", " + tm);
+		log(() -> "beforeConfiguration: " + tr + ", " + tm);
+	}
+
+	private void log(Supplier<String> message) {
+		LOGGER.fine(message);
 	}
 }

--- a/src/main/java/org/junit/support/testng/engine/TestClassRegistry.java
+++ b/src/main/java/org/junit/support/testng/engine/TestClassRegistry.java
@@ -17,6 +17,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 class TestClassRegistry {
 
@@ -42,13 +43,13 @@ class TestClassRegistry {
 		return Optional.ofNullable(entry).map(it -> it.descriptor);
 	}
 
-	void finish(Class<?> testClass, Consumer<ClassDescriptor> onLast) {
+	void finish(Class<?> testClass, Predicate<ClassDescriptor> last, Consumer<ClassDescriptor> onLast) {
 		testClasses.compute(testClass, (__, value) -> {
 			if (value == null) {
 				return null;
 			}
 			int inProgress = value.inProgress.decrementAndGet();
-			if (inProgress == 0) {
+			if (inProgress == 0 && last.test(value.descriptor)) {
 				onLast.accept(value.descriptor);
 				return null;
 			}

--- a/src/test/java/org/junit/support/testng/engine/DataProviderIntegrationTests.java
+++ b/src/test/java/org/junit/support/testng/engine/DataProviderIntegrationTests.java
@@ -32,11 +32,7 @@ import static org.junit.platform.testkit.engine.EventConditions.uniqueIdSubstrin
 import static org.junit.platform.testkit.engine.TestExecutionResultConditions.cause;
 import static org.junit.platform.testkit.engine.TestExecutionResultConditions.message;
 
-import example.dataproviders.DataProviderMethodEmptyListTestCase;
-import example.dataproviders.DataProviderMethodErrorHandlingTestCase;
-import example.dataproviders.DataProviderMethodTestCase;
-import example.dataproviders.FactoryWithDataProviderTestCase;
-import example.dataproviders.ParallelDataProviderTestCase;
+import example.dataproviders.*;
 
 import org.junit.jupiter.api.Test;
 import org.junit.platform.engine.TestDescriptor;
@@ -167,6 +163,29 @@ class DataProviderIntegrationTests extends AbstractIntegrationTests {
 			event(test("method:b()@1"), started()), //
 			event(test("method:b()@1"), finishedWithFailure(message("b"))), //
 			event(testClass(FactoryWithDataProviderTestCase.class), finishedSuccessfully()));
+	}
+
+	@Test
+	void executesFactoryMethodTestClass() {
+		var results = testNGEngine().selectors(selectClass(FactoryMethodTestCase.class)).execute();
+
+		results.allEvents().debug();
+
+		results.containerEvents().assertEventsMatchExactly( //
+			event(engine(), started()), //
+			event(testClass(FactoryMethodTestCase.class), started()), //
+			event(testClass(FactoryMethodTestCase.class), finishedSuccessfully()), //
+			event(engine(), finishedSuccessfully()));
+		results.allEvents().assertEventsMatchLooselyInOrder( //
+			event(testClass(FactoryMethodTestCase.class), started()), //
+			event(test("method:test()@0"), started()), //
+			event(test("method:test()@0"), finishedSuccessfully()), //
+			event(testClass(FactoryMethodTestCase.class), finishedSuccessfully()));
+		results.allEvents().assertEventsMatchLooselyInOrder( //
+			event(testClass(FactoryMethodTestCase.class), started()), //
+			event(test("method:test()@1"), started()), //
+			event(test("method:test()@1"), finishedSuccessfully()), //
+			event(testClass(FactoryMethodTestCase.class), finishedSuccessfully()));
 	}
 
 	@Test

--- a/src/test/java/org/junit/support/testng/engine/DataProviderIntegrationTests.java
+++ b/src/test/java/org/junit/support/testng/engine/DataProviderIntegrationTests.java
@@ -189,6 +189,7 @@ class DataProviderIntegrationTests extends AbstractIntegrationTests {
 	}
 
 	@Test
+	@RequiresTestNGVersion(maxExclusive = "7.6")
 	void reportsExceptionInDataProviderMethodAsAborted() {
 		var testClass = DataProviderMethodErrorHandlingTestCase.class;
 
@@ -198,6 +199,20 @@ class DataProviderIntegrationTests extends AbstractIntegrationTests {
 			event(testClass(testClass), started()), //
 			event(container("method:test(int)"), started()), //
 			event(container("method:test(int)"), abortedWithReason(cause(message("exception in data provider")))), //
+			event(testClass(testClass), finishedSuccessfully()));
+	}
+
+	@Test
+	@RequiresTestNGVersion(min = "7.6")
+	void reportsExceptionInDataProviderMethodAsFailed() {
+		var testClass = DataProviderMethodErrorHandlingTestCase.class;
+
+		var results = testNGEngine().selectors(selectClass(testClass)).execute();
+
+		results.allEvents().debug().assertEventsMatchLooselyInOrder( //
+			event(testClass(testClass), started()), //
+			event(container("method:test(int)"), started()), //
+			event(container("method:test(int)"), finishedWithFailure(cause(message("exception in data provider")))), //
 			event(testClass(testClass), finishedSuccessfully()));
 	}
 

--- a/src/test/java/org/junit/support/testng/engine/RequiresTestNGVersion.java
+++ b/src/test/java/org/junit/support/testng/engine/RequiresTestNGVersion.java
@@ -35,7 +35,7 @@ import org.junit.platform.commons.support.AnnotationSupport;
 
 	String min() default "";
 
-	String max() default "";
+	String maxExclusive() default "";
 
 	String[] except() default {};
 
@@ -48,9 +48,10 @@ import org.junit.platform.commons.support.AnnotationSupport;
 
 		private ConditionEvaluationResult satisfiesRequirements(RequiresTestNGVersion requirements) {
 			var actualVersion = testNGVersion();
-			if (!requirements.max().isBlank()
-					&& actualVersion.compareTo(new ComparableVersion(requirements.max())) > 0) {
-				return disabled("max constraint not met: %s > %s".formatted(actualVersion, requirements.max()));
+			if (!requirements.maxExclusive().isBlank()
+					&& actualVersion.compareTo(new ComparableVersion(requirements.maxExclusive())) >= 0) {
+				return disabled(
+					"maxExclusive constraint not met: %s > %s".formatted(actualVersion, requirements.maxExclusive()));
 			}
 			if (!requirements.min().isBlank()
 					&& actualVersion.compareTo(new ComparableVersion(requirements.min())) < 0) {

--- a/src/test/java/org/junit/support/testng/engine/TestContext.java
+++ b/src/test/java/org/junit/support/testng/engine/TestContext.java
@@ -10,11 +10,13 @@
 
 package org.junit.support.testng.engine;
 
+import static org.apache.commons.lang3.StringUtils.removeEnd;
+
 import org.apache.maven.artifact.versioning.ComparableVersion;
 
 class TestContext {
 
 	static ComparableVersion testNGVersion() {
-		return new ComparableVersion(System.getProperty("testng.version", "7.5"));
+		return new ComparableVersion(removeEnd(System.getProperty("testng.version", "7.5"), "-SNAPSHOT"));
 	}
 }

--- a/src/testFixtures/java/example/dataproviders/FactoryMethodTestCase.java
+++ b/src/testFixtures/java/example/dataproviders/FactoryMethodTestCase.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.dataproviders;
+
+import static org.testng.Assert.assertNotEquals;
+
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+
+public class FactoryMethodTestCase {
+
+	private final String a;
+	private final String b;
+
+	@Factory
+	public static Object[] factoryData() {
+		return new Object[] { new FactoryMethodTestCase("a", "b"), new FactoryMethodTestCase("c", "d") };
+	}
+
+	public FactoryMethodTestCase(String a, String b) {
+		this.a = a;
+		this.b = b;
+	}
+
+	@Test
+	public void test() {
+		assertNotEquals(a, b);
+	}
+}


### PR DESCRIPTION
- Fix reporting of tests created via `Factory` methods
- Fix reporting of failing data provider methods in 7.6.x
- Remove duplication
- Add CI build for JDK 19

Fixes gradle/gradle#20670.
