### PR TITLE
Report skipped config methods as aborted test classes

### DIFF
--- a/src/test/java/org/junit/support/testng/engine/ReportingIntegrationTests.java
+++ b/src/test/java/org/junit/support/testng/engine/ReportingIntegrationTests.java
@@ -42,6 +42,7 @@ import example.basics.RetriedTestCase;
 import example.basics.SimpleTestCase;
 import example.basics.SuccessPercentageTestCase;
 import example.basics.TimeoutTestCase;
+import example.configuration.methods.AbortedBeforeClassConfigurationMethodTestCase;
 import example.configuration.methods.FailingBeforeClassConfigurationMethodTestCase;
 import example.dataproviders.DataProviderMethodTestCase;
 
@@ -115,6 +116,17 @@ class ReportingIntegrationTests extends AbstractIntegrationTests {
 			event(testClass(FailingBeforeClassConfigurationMethodTestCase.class), started()), //
 			event(testClass(FailingBeforeClassConfigurationMethodTestCase.class),
 				finishedWithFailure(message("boom"))));
+	}
+
+	@Test
+	void reportsAbortedBeforeClassMethod() {
+		var results = testNGEngine().selectors(
+			selectClass(AbortedBeforeClassConfigurationMethodTestCase.class)).execute();
+
+		results.allEvents().debug().assertEventsMatchLooselyInOrder( //
+			event(testClass(AbortedBeforeClassConfigurationMethodTestCase.class), started()), //
+			event(testClass(AbortedBeforeClassConfigurationMethodTestCase.class),
+				abortedWithReason(message("not today"))));
 	}
 
 	@Test

--- a/src/testFixtures/java/example/configuration/methods/AbortedBeforeClassConfigurationMethodTestCase.java
+++ b/src/testFixtures/java/example/configuration/methods/AbortedBeforeClassConfigurationMethodTestCase.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.configuration.methods;
+
+import org.testng.SkipException;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class AbortedBeforeClassConfigurationMethodTestCase {
+
+	@BeforeClass
+	public void beforeClass() {
+		throw new SkipException("not today");
+	}
+
+	@Test
+	public void test() {
+		// never called
+	}
+}


### PR DESCRIPTION
Prior to this commit such test classes were reported as successful
